### PR TITLE
Make ranking subquery a configuration option

### DIFF
--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -75,16 +75,20 @@ module PgSearch
       options[:order_within_rank]
     end
 
+    def rank_with_subquery?
+      options[:rank_subquery]
+    end
+
     private
 
     attr_reader :options
 
     def default_options
-      {using: :tsearch}
+      {using: :tsearch, rank_subquery: true}
     end
 
     VALID_KEYS = %w[
-      against ranked_by ignoring using query associated_against order_within_rank
+      against ranked_by ignoring using query associated_against order_within_rank rank_subquery
     ].map(&:to_sym)
 
     VALID_VALUES = {


### PR DESCRIPTION
## Description
These changes add the ability to disable a subquery join to manage ranking sort. Now by setting `rank_subquery: false` the results will be filtered by and ordered in the main query. This results in faster execution times when dealing with large tables and loose search terms.

## Examples:
Query: `Page.where(source_document_id: 1016).fast_text_search('example')`
Old behavior produces the following query:
```sql
SELECT "pages".* FROM "pages" 
INNER JOIN (
  SELECT "pages"."id" AS pg_search_id, (ts_rank(("pages"."text_tsvector"), (to_tsquery('simple', ''' ' || 'example' || ' ''' || ':*')), 0)) AS rank 
  FROM "pages" 
  WHERE (("pages"."text_tsvector") @@ (to_tsquery('simple', ''' ' || 'example' || ' ''' || ':*')))
) AS pg_search_bfa062de040f55a15ce910 
  ON "pages"."id" = pg_search_bfa062de040f55a15ce910.pg_search_id 
WHERE "pages"."source_document_id" = 1016 
ORDER BY pg_search_bfa062de040f55a15ce910.rank DESC, "pages"."id" ASC
```

Setting `rank_subquery:false` now produces:
```sql
SELECT "pages".* 
FROM "pages" 
WHERE "pages"."source_document_id" = 1016 
  AND (("pages"."text_tsvector") @@ (to_tsquery('simple', ''' ' || 'example' || ' ''' || ':*'))) 
ORDER BY (ts_rank(("pages"."text_tsvector"), (to_tsquery('simple', ''' ' || 'example' || ' ''' || ':*')), 0)) DESC, "pages"."id" ASC
```